### PR TITLE
Updates for compatibility with DeePMD 3.0

### DIFF
--- a/arcann_training/training/check.py
+++ b/arcann_training/training/check.py
@@ -156,7 +156,7 @@ def main(
     if min_nbor_dist is not None:
         training_json["min_nbor_dist"] = min_nbor_dist
         arcann_logger.info(f"Your minimum neighbor distance is: {min_nbor_dist:.3f}")
-        if min_nbor_dist < 0.7:
+        if min_nbor_dist < 0.1:
             arcann_logger.warning(
                 f"Your minimum neighbor distance is lower than 0.1 Angstrom."
             )

--- a/arcann_training/training/check.py
+++ b/arcann_training/training/check.py
@@ -78,6 +78,7 @@ def main(
     min_nbor_dist = None
     max_nbor_size = None
     training_input_json = None
+    deepmd_version = training_json["deepmd_model_version"]
 
     for nnp in range(1, main_json["nnp_count"] + 1):
         local_path = current_path / f"{nnp}"
@@ -92,8 +93,13 @@ def main(
             if any("finished training" in s for s in training_out):
                 training_out_time = [s for s in training_out if "training time" in s]
 
-                batch_pattern = r"batch\s*(\d+)\s"
-                time_pattern = r"training time (\d+\.\d+) s"
+                if deepmd_version == 3.0:
+                    batch_pattern = r"batch\s*(\d+)\b"
+                    time_pattern = r"wall time = (\d+\.\d+) s"
+                
+                else: 
+                    batch_pattern = r"batch\s*(\d+)\s"
+                    time_pattern = r"training time (\d+\.\d+) s"
 
                 if min_nbor_dist is None or max_nbor_size is None:
                     for log_text in training_out:

--- a/arcann_training/training/utils.py
+++ b/arcann_training/training/utils.py
@@ -328,13 +328,13 @@ def validate_deepmd_config(training_config) -> None:
     Raises
     ------
     ValueError
-        If deepmd_model_version is not 2.0 or 2.1, or if deepmd_model_type_descriptor is not "se_e2_a".
+        If deepmd_model_version is not 2.0 or 2.1 or 3.0, or if deepmd_model_type_descriptor is not "se_e2_a".
         If the configuration is not valid with respect to machine/arch_name/arch and DeePMD.
     """
     # Check DeePMD version
     if (
         float(training_config["deepmd_model_version"]) < 2.0
-        or float(training_config["deepmd_model_version"]) >= 3.0
+        or float(training_config["deepmd_model_version"]) > 3.0
     ):
-        error_msg = f"Only 2.x version of deepmd are suppported: '{training_config['deepmd_model_version']}'."
+        error_msg = f"Only 2.x and 3.0 versions of deepmd are suppported: '{training_config['deepmd_model_version']}'."
         raise ValueError(error_msg)

--- a/arcann_training/training/utils.py
+++ b/arcann_training/training/utils.py
@@ -328,7 +328,7 @@ def validate_deepmd_config(training_config) -> None:
     Raises
     ------
     ValueError
-        If deepmd_model_version is not 2.0 or 2.1 or 3.0, or if deepmd_model_type_descriptor is not "se_e2_a".
+        If deepmd_model_version is not 2.x or 3.0, or if deepmd_model_type_descriptor is not "se_e2_a".
         If the configuration is not valid with respect to machine/arch_name/arch and DeePMD.
     """
     # Check DeePMD version

--- a/docs/usage/iter_prerequisites.md
+++ b/docs/usage/iter_prerequisites.md
@@ -25,7 +25,7 @@ In `user_files/` you will store all the files needed for each step. You can find
 
 
 - For the training step, from `training_deepmd` you will need: 
-    - A DeePMD-kit JSON file named `dptrain_VERSION.json`, where `VERSION` is the DeePMD-kit version that you will use (*e.g.*, `2.1`; currently supported versions are `2.0`, `2.1`, and `2.2`).
+    - A DeePMD-kit JSON file named `dptrain_VERSION.json`, where `VERSION` is the DeePMD-kit version that you will use (*e.g.*, `2.1`; currently supported versions are `2.0`, `2.1`, `2.2`, and `3.0`).
 
 
 - The SLURM scripts for individual jobs and for job arrays are organised by step in several fordels. Prepare your files according to your software choice for each step. You can fin them in: 

--- a/examples/user_files/job_exploration_lammps_slurm/job-array_lammps-deepmd_explore_gpu_myHPCkeyword1.sh
+++ b/examples/user_files/job_exploration_lammps_slurm/job-array_lammps-deepmd_explore_gpu_myHPCkeyword1.sh
@@ -84,6 +84,9 @@ if [ "${DeepMD_MODEL_VERSION}" == "2.2" ]; then
 elif [ "${DeepMD_MODEL_VERSION}" == "2.1" ]; then
     # Load the DeepMD module
     module load "DeepMD-kit/${DeepMD_MODEL_VERSION}"
+elif [ "${DeepMD_MODEL_VERSION}" == "3.0" ]; then
+    # Load the DeepMD module
+    module load "DeepMD-kit/${DeepMD_MODEL_VERSION}"
 else
     echo "DeepMD version ${DeepMD_MODEL_VERSION} is not available. Aborting..."
     exit 1

--- a/examples/user_files/job_exploration_lammps_slurm/job_lammps-deepmd_explore_gpu_myHPCkeyword1.sh
+++ b/examples/user_files/job_exploration_lammps_slurm/job_lammps-deepmd_explore_gpu_myHPCkeyword1.sh
@@ -63,6 +63,9 @@ if [ "${DeepMD_MODEL_VERSION}" == "2.2" ]; then
 elif [ "${DeepMD_MODEL_VERSION}" == "2.1" ]; then
     # Load the DeepMD module
     module load "DeepMD-kit/${DeepMD_MODEL_VERSION}"
+elif [ "${DeepMD_MODEL_VERSION}" == "3.0" ]; then
+    # Load the DeepMD module
+    module load "DeepMD-kit/${DeepMD_MODEL_VERSION}"
 else
     echo "DeepMD version ${DeepMD_MODEL_VERSION} is not available. Aborting..."
     exit 1

--- a/examples/user_files/job_training_deepmd_slurm/job_deepmd_compress_gpu_myHPCkeyword1.sh
+++ b/examples/user_files/job_training_deepmd_slurm/job_deepmd_compress_gpu_myHPCkeyword1.sh
@@ -62,6 +62,9 @@ if [ ${DeepMD_MODEL_VERSION} == "2.2" ]; then
 elif [ ${DeepMD_MODEL_VERSION} == "2.1" ]; then
     # Load the DeepMD module
     module load DeepMD-kit/${DeepMD_MODEL_VERSION}
+elif [ ${DeepMD_MODEL_VERSION} == "3.0" ]; then
+    # Load the DeepMD module
+    module load DeepMD-kit/${DeepMD_MODEL_VERSION}
 else
     echo "DeepMD version ${DeepMD_MODEL_VERSION} is not available. Aborting..."
     exit 1

--- a/examples/user_files/job_training_deepmd_slurm/job_deepmd_freeze_gpu_myHPCkeyword1.sh
+++ b/examples/user_files/job_training_deepmd_slurm/job_deepmd_freeze_gpu_myHPCkeyword1.sh
@@ -62,6 +62,9 @@ if [ ${DeepMD_MODEL_VERSION} == "2.2" ]; then
 elif [ ${DeepMD_MODEL_VERSION} == "2.1" ]; then
     # Load the DeepMD module
     module load DeepMD-kit/${DeepMD_MODEL_VERSION}
+elif [ ${DeepMD_MODEL_VERSION} == "3.0" ]; then
+    # Load the DeepMD module
+    module load DeepMD-kit/${DeepMD_MODEL_VERSION}
 else
     echo "DeepMD version ${DeepMD_MODEL_VERSION} is not available. Aborting..."
     exit 1

--- a/examples/user_files/job_training_deepmd_slurm/job_deepmd_train_gpu_myHPCkeyword1.sh
+++ b/examples/user_files/job_training_deepmd_slurm/job_deepmd_train_gpu_myHPCkeyword1.sh
@@ -67,7 +67,7 @@ if [ ${DeepMD_MODEL_VERSION} == "2.2" ]; then
 elif [ ${DeepMD_MODEL_VERSION} == "2.1" ]; then
     # Load the DeepMD module
     module load DeepMD-kit/${DeepMD_MODEL_VERSION}
-elif [ ${DeepMD_MODEL_VERSION} == "2.1" ]; then
+elif [ ${DeepMD_MODEL_VERSION} == "3.0" ]; then
     # Load the DeepMD module
     module load DeepMD-kit/${DeepMD_MODEL_VERSION}
 else

--- a/examples/user_files/job_training_deepmd_slurm/job_deepmd_train_gpu_myHPCkeyword1.sh
+++ b/examples/user_files/job_training_deepmd_slurm/job_deepmd_train_gpu_myHPCkeyword1.sh
@@ -67,6 +67,9 @@ if [ ${DeepMD_MODEL_VERSION} == "2.2" ]; then
 elif [ ${DeepMD_MODEL_VERSION} == "2.1" ]; then
     # Load the DeepMD module
     module load DeepMD-kit/${DeepMD_MODEL_VERSION}
+elif [ ${DeepMD_MODEL_VERSION} == "2.1" ]; then
+    # Load the DeepMD module
+    module load DeepMD-kit/${DeepMD_MODEL_VERSION}
 else
     echo "DeepMD version ${DeepMD_MODEL_VERSION} is not available. Aborting..."
     exit 1

--- a/examples/user_files/training_deepmd/training_3.0.json
+++ b/examples/user_files/training_deepmd/training_3.0.json
@@ -1,0 +1,55 @@
+{
+    "model": {
+      "type_map": ["O", "H"],
+      "descriptor": {
+        "type": "se_e2_a",
+        "sel": [46, 92],
+        "rcut_smth": 0.50,
+        "rcut": 6.00,
+        "neuron": [25, 50, 100],
+        "resnet_dt": false,
+        "axis_neuron": 16,
+        "type_one_side": true,
+        "precision": "float64",
+        "seed": 1
+      },
+      "fitting_net": {
+        "neuron": [240, 240, 240],
+        "resnet_dt": true,
+        "precision": "float64",
+        "seed": 1
+      }
+    },
+    "learning_rate": {
+      "type": "exp",
+      "decay_steps": 5000,
+      "start_lr": 0.001,
+      "stop_lr": 1.0e-6
+    },
+    "loss": {
+      "type": "ener",
+      "start_pref_e": 0.02,
+      "limit_pref_e": 2.0,
+      "start_pref_f": 1000.0,
+      "limit_pref_f": 1.0,
+      "start_pref_v": 0.0,
+      "limit_pref_v": 0.0
+    },
+    "training": {
+      "seed": 10,
+      "numb_steps": 1000000,
+      "disp_file": "lcurve.out",
+      "disp_freq": 1000,
+      "numb_test": 0,
+      "save_freq": 1000,
+      "save_ckpt": "model.ckpt",
+      "disp_training": true,
+      "time_training": true,
+      "profiling": false,
+      "training_data": {
+        "systems": ["../data/"],
+        "batch_size": 1,
+        "set_prefix": "set"
+      }
+    }
+  }


### PR DESCRIPTION
- Added logic in `arcann_training/training/check.py` to read the training log, which differs between versions 2.x and 3.0
- Fixed typo in the code `arcann_training/training/check.py` where min_nbor_dist was inconsistent with the logged message
- Updated `arcann_training/training/utils.py` to allow version 3.0
- Updated documentation to reflect 3.0 compatibility
- Updated example files to reflect 3.0 availability